### PR TITLE
Add PocketBaseUML

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ This is a collection of [PocketBase](https://pocketbase.io) community resources.
 * [PocketBase+Litestream example](https://github.com/TylerSustare/pocketbase-framework-litestream) - Template showing Litestream running with PocketBase.
 * [PocketBase with Litestream](https://github.com/bscott/pocketbase-litestream/) - Docker example of PocketBase saving/restoring from Litestream.
 
+## Other tools
+
+* [PocketBaseUML](https://pocketbase-uml.github.io/) - A free, open-source web application that generates UML diagrams based on PocketBase databases.
+
 ## Forks
 
 * [Enchanted PocketBase](https://github.com/benallfree/pocketbase) - A PocketBase fork with PBScript built-in and other realtime enhancements


### PR DESCRIPTION
Hey @benallfree, just wanted to contribute my repo to the list: [PocketBaseUML](https://pocketbase-uml.github.io/) is a free, open-source UML diagram generator for PocketBase. Though PocketBase already comes with a fantastic UI (better than Supabase or Firebase, IMO), I was missing the ability to actually SEE the data architecture in a graphical form, easy to parse and understand in a quick glance.