### PR TITLE
Updated Kotlin SDK url

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This is a collection of [PocketBase](https://pocketbase.io) community resources.
 ## Unofficial PocketBase Clients (SDKs)
 
 * [Go](https://github.com/r--w/pocketbase)
-* [Kotlin](https://github.com/OtisGoodman/pocket-kt)
+* [Kotlin](https://github.com/agrevster/pocketbase-kotlin)
 * [Python](https://github.com/vaphes/pocketbase)
 * [C#](https://github.com/PRCV1/pocketbase-csharp-sdk)
 * [Rust](https://github.com/sreedevk/pocketbase-sdk-rust)


### PR DESCRIPTION
I deleted my GitHub and made a new one, I changed the Kotlin SDK URL.