### PR TITLE
Remove dead link to pocketbase-ts repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ PocketBase is an open source backend consisting of embedded database (SQLite) wi
 
 - [pb_hooks starter kit](https://github.com/benallfree/ts-pb-hooks-starter) - Build PocketBase JavaScript hooks using TypeScript.
 - [PocketBase Typegen](https://github.com/patmood/pocketbase-typegen) - Generate TypeScript types from the SQLite db file.
-- [pocketbase-ts](https://github.com/Solaris9/pocketbase-ts) - A simplified PocketBase SDK to ease the developer experience. Modular API. Strongly typed Schemas.
 - [typed-pocketbase](https://github.com/david-plugge/typed-pocketbase) - Generate types from your PocketBase instance and enjoy fully type-safe queries.
 
 ## SQLite tools


### PR DESCRIPTION
This PR removes the link to [https://github.com/Solaris9/pocketbase-ts](https://github.com/Solaris9/pocketbase-ts) since the repository no longer exists.