### PR TITLE
Add: jianyuan/pocketbase-nextjs-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ PocketBase is an open source backend consisting of embedded database (SQLite) wi
 
 ## React
 
-- [Next.js PocketBase Auth](https://github.com/jianyuan/pocketbase-nextjs-auth) — Sample Next.js 15 application with PocketBase integration, a typed client, server-side and client-side rendering techniques, and server actions.
+- [Next.js PocketBase Auth](https://github.com/jianyuan/pocketbase-nextjs-auth) - Sample Next.js 15 application with PocketBase integration, a typed client, server-side and client-side rendering techniques, and server actions.
 - [PocketBase React](https://github.com/tobicrain/pocketbase-react) - Unofficial React SDK (React, React Native, Expo) for interacting with the PocketBase JavaScript SDK. ![GitHub Repo stars](https://img.shields.io/github/stars/tobicrain/pocketbase-react)
 - [PocketBase Next.js App Template](https://github.com/tsensei/nextjs-pocketbase-starter-template) - PocketBase Next.js Template with server & browser client using cookies. ![GitHub Repo stars](https://img.shields.io/github/stars/tsensei/nextjs-pocketbase-starter-template)
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ PocketBase is an open source backend consisting of embedded database (SQLite) wi
 
 ## React
 
-- [Next.js PocketBase Auth](https://github.com/jianyuan/pocketbase-nextjs-auth) - Sample Next.js 15 application with PocketBase integration, a typed client, server-side and client-side rendering techniques, and server actions.
 - [PocketBase React](https://github.com/tobicrain/pocketbase-react) - Unofficial React SDK (React, React Native, Expo) for interacting with the PocketBase JavaScript SDK. ![GitHub Repo stars](https://img.shields.io/github/stars/tobicrain/pocketbase-react)
 - [PocketBase Next.js App Template](https://github.com/tsensei/nextjs-pocketbase-starter-template) - PocketBase Next.js Template with server & browser client using cookies. ![GitHub Repo stars](https://img.shields.io/github/stars/tsensei/nextjs-pocketbase-starter-template)
+- [Next.js PocketBase Auth](https://github.com/jianyuan/pocketbase-nextjs-auth) - Sample Next.js 15 application with PocketBase integration, a typed client, server-side and client-side rendering techniques, and server actions. ![GitHub Repo stars](https://img.shields.io/github/stars/jianyuan/pocketbase-nextjs-auth)
 
 ## Svelte
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ PocketBase is an open source backend consisting of embedded database (SQLite) wi
 
 ## React
 
+- [Next.js PocketBase Auth](https://github.com/jianyuan/pocketbase-nextjs-auth) — Sample Next.js 15 application with PocketBase integration, a typed client, server-side and client-side rendering techniques, and server actions.
 - [PocketBase React](https://github.com/tobicrain/pocketbase-react) - Unofficial React SDK (React, React Native, Expo) for interacting with the PocketBase JavaScript SDK. ![GitHub Repo stars](https://img.shields.io/github/stars/tobicrain/pocketbase-react)
 - [PocketBase Next.js App Template](https://github.com/tsensei/nextjs-pocketbase-starter-template) - PocketBase Next.js Template with server & browser client using cookies. ![GitHub Repo stars](https://img.shields.io/github/stars/tsensei/nextjs-pocketbase-starter-template)
 


### PR DESCRIPTION
[Next.js PocketBase Auth](https://github.com/jianyuan/pocketbase-nextjs-auth) — Sample Next.js 15 application with PocketBase integration, a typed client, server-side and client-side rendering techniques, and server actions.