### PR TITLE
Add pocketbase-schema-generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ PocketBase is an open source backend consisting of embedded database (SQLite) wi
 - [typed-pocketbase](https://github.com/david-plugge/typed-pocketbase) - Generate types from your PocketBase instance and enjoy fully type-safe queries. ![GitHub Repo stars](https://img.shields.io/github/stars/david-plugge/typed-pocketbase)
 - [pocketbase-ts](https://github.com/satohshi/pocketbase-ts) - SDK wrapper with more readable `options` syntax and full type-safety. ![GitHub Repo stars](https://img.shields.io/github/stars/satohshi/pocketbase-ts)
 - [pocketbase-query](https://github.com/emresandikci/pocketbase-query) - is a TypeScript-based query builder designed to generate complex filter queries for PocketBase. It allows for easy construction of queries using various operators while maintaining a fluent and chainable API. ![GitHub Repo stars](https://img.shields.io/github/stars/emresandikci/pocketbase-query)
+- [pocketbase-schema-generator](https://github.com/satohshi/pocketbase-schema-generator) - JS hook for automatically generating schema files. (Zod/TS interfaces) ![GitHub Repo stars](https://img.shields.io/github/stars/satohshi/pocketbase-schema-generator)
 
 ## SQLite tools
 


### PR DESCRIPTION
Adding [pocketbase-schema-generator](https://github.com/satohshi/pocketbase-schema-generator), JS hook that auto-generates/updates Zod schema and TypeScript interfaces every time you make a change to your collections