### PR TITLE
Add pocketbase-libsql - PoC for horizontally scaling pocketbase 

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ PocketBase is an open source backend consisting of embedded database (SQLite) wi
 - [JustJot](https://justjot.app) - A keyboard-first note-taking full-featured Progressive Web App. [frontend repo](https://github.com/JunoNgx/justjot-frontend) / [backend repo](https://github.com/JunoNgx/justjot-backend) ![GitHub Repo stars](https://img.shields.io/github/stars/JunoNgx/justjot-backend)
 - [Cookie auth demo](https://github.com/davidbarton/pocketbase-cookie-auth-demo) - A demo of cookie based authentication flow for PocketBase. ![GitHub Repo stars](https://img.shields.io/github/stars/davidbarton/pocketbase-cookie-auth-demo)
 - [Adnexos](https://github.com/tametsi/adnexos) - Self-hostable expense-splitter on the web. ![GitHub Repo stars](https://img.shields.io/github/stars/tametsi/adnexos)
+- [pocketbase-libsql](https://github.com/cobeo2004/pocketbase-libsql) - Scaling Pocketbase with LibSQL and sqld - a Proof Of Concept ![GitHub Repo stars](https://img.shields.io/github/stars/cobeo2004/pocketbase-libsql)
 
 ## PocketPorts Packages
 


### PR DESCRIPTION
### Title: Add pocketbase-libsql -  PoC for horizontally scaling pocketbase 

- Description: [pocketbase-libsql](https://github.com/cobeo2004/pocketbase-libsql) - Is a Proof-of-Concept (PoC) that showcases how to horizontally scale PocketBase by leveraging LibSQL's distributed database capabilities. The architecture implements a primary-replica pattern with multiple PocketBase instances connected to replicated databases, all fronted by a load balancer.

- Checklist:
- [x] The project is over 30 days old.
- [x] The format follows the guidelines: [Resource Title](url) — description.
- [x] Spelling and grammar have been checked.