### PR TITLE
Add PBLauncher to the Self-Hosting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ PocketBase is an open source backend consisting of embedded database (SQLite) wi
 - [LocalXpose](https://localxpose.io/docs/tutorials/expose-pocketbase-backend) - Allow public access to a localhost instance.
 - [PocketBase Docker](https://github.com/kdpuvvadi/pocketbase) - Docker images supporting multiple architectures and updated with latest PocketBase releases. ![GitHub Repo stars](https://img.shields.io/github/stars/kdpuvvadi/pocketbase)
 - [PocketBase on Dokku](https://github.com/blockshiftnetwork/dokku-pocketbase) - Deploy PocketBase instances on Dokku effortlessly. ![GitHub Repo stars](https://img.shields.io/github/stars/blockshiftnetwork/dokku-pocketbase)
-- [PBLauncher](https://github.com/user0608/pb_launcher) - Manage PocketBase instances — fast, lightweight, open source
+- [PBLauncher](https://github.com/user0608/pb_launcher) - Manage PocketBase instances — fast, lightweight, open source. ![GitHub Repo stars](https://img.shields.io/github/stars/user0608/pb_launcher)
+
 ## TypeScript tools
 
 - [pocketbase-jsvm](https://github.com/benallfree/pocketbase-jsvm) - JSVM typings. ![GitHub Repo stars](https://img.shields.io/github/stars/benallfree/pocketbase-jsvm)


### PR DESCRIPTION
[PBLauncher](https://github.com/user0608/pb_launcher) — Fast, lightweight, open source binary written in Go for managing PocketBase instances with HTTPS and custom domain support.

PBLauncher makes it easy to self-host and manage multiple PocketBase instances securely, all from a single Go binary.